### PR TITLE
ci: Dependabot monthly + group minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
@@ -35,7 +35,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Reduce Dependabot churn & Actions cost: version updates monthly instead of weekly/daily, and minor+patch grouped into a single PR per ecosystem (majors stay individual so they get attention). Security updates are unaffected (they remain immediate).
